### PR TITLE
Select option patch

### DIFF
--- a/MlogDocs/ProcessorUI/index.html
+++ b/MlogDocs/ProcessorUI/index.html
@@ -735,6 +735,12 @@
             <div id="setBlockOre">ore</div>
             <div>block</div>
         </div>
+        <div id="getBlockMenu" class="popUpMenu">
+            <div>floor</div>
+            <div>ore</div>
+            <div>block</div>
+            <div>building</div>
+        </div>
         <div id="applyStatusMenu" class="popUpMenu">
             <div>wet</div>
             <div>burning</div>

--- a/MlogDocs/ProcessorUI/script.js
+++ b/MlogDocs/ProcessorUI/script.js
@@ -1857,6 +1857,8 @@ function selectOption(event,id,isImport,importSelectionValue,isOnInput,from) {
                 case 'explosion':
                     main([2, 3, 4, 44], {44: 'size'});
                     break;
+                default:
+                    console.error(`Unhandled effectMenu selection ${option}`);
             }
             break;
         case 'fetchMenu':
@@ -1881,6 +1883,8 @@ function selectOption(event,id,isImport,importSelectionValue,isOnInput,from) {
                 case 'buildCount':
                     main([5,55], {55: 'block'})
                     break;
+                default:
+                    console.error(`Unhandled fetchMenu selection ${option}`);
             }
             break;
         case 'controlMenu':
@@ -1896,6 +1900,8 @@ function selectOption(event,id,isImport,importSelectionValue,isOnInput,from) {
                 case 'shootp':
                     main([2, 3, 4, 33, 44], {33: 'unit', 44: 'shoot'})
                     break;
+                default:
+                    console.error(`Unhandled controlMenu selection ${option}`);
             }
             break;
         case 'setMarkerMenu':
@@ -1960,6 +1966,8 @@ function selectOption(event,id,isImport,importSelectionValue,isOnInput,from) {
                 case 'colori':
                     main([22, 2, 33, 3, 44, 4], {22: 'of id#', 33: 'index', 44: 'color'})
                     break;
+                default:
+                    console.error(`Unhandled setMarkerMenu selection ${option}`);
             }
             break;
         case 'jumpMenu':
@@ -2028,6 +2036,8 @@ function selectOption(event,id,isImport,importSelectionValue,isOnInput,from) {
                 case 'rotate':
                     main([11,1], {11:'degrees'})
                     break;
+                default:
+                    console.error(`Unhandled drawMenu selection ${option}`);
             }
             break;
         case 'ucontrolMenu':
@@ -2082,6 +2092,8 @@ function selectOption(event,id,isImport,importSelectionValue,isOnInput,from) {
                 case 'within':
                     main([11,22,33,44,1,2,3,4,5], {11:'x',22:'y',33:'radius',44:'result'})
                     break;
+                default:
+                    console.error(`Unhandled ucontrolMenu selection ${option}`);
             }
             break;
         case 'ulocateFindMenu':
@@ -2096,6 +2108,8 @@ function selectOption(event,id,isImport,importSelectionValue,isOnInput,from) {
                 case 'spawn':
                     main([-1])
                     break;
+                default:
+                    console.error(`Unhandled ulocateFindMenu selection ${option}`);
             }
             break;
         case 'setBlockMenu':
@@ -2105,6 +2119,8 @@ function selectOption(event,id,isImport,importSelectionValue,isOnInput,from) {
                 case 'block':
                     main([5,6])
                     break;
+                default:
+                    console.error(`Unhandled setBlockMenu selection ${option}`);
             }
             break;
         case 'flushMessageMenu':
@@ -2117,6 +2133,8 @@ function selectOption(event,id,isImport,importSelectionValue,isOnInput,from) {
                 case 'toast':
                     main([1,3])
                     break;
+                default:
+                    console.error(`Unhandled flushMessageMenu selection ${option}`);
             }
             break;
         case 'cutsceneMenu':
@@ -2130,6 +2148,8 @@ function selectOption(event,id,isImport,importSelectionValue,isOnInput,from) {
                 case 'stop':
                     main([1])
                     break;
+                default:
+                    console.error(`Unhandled cutsceneMenu selection ${option}`);
             }
             break;
         case 'printCharMenu':

--- a/MlogDocs/ProcessorUI/script.js
+++ b/MlogDocs/ProcessorUI/script.js
@@ -1989,10 +1989,11 @@ function selectOption(event,id,isImport,importSelectionValue,isOnInput,from) {
         case 'drawMenu':
             switch(option){
                 case 'clear':
-                    main([11,22,33,1,2,3])
+                    // field 3 is the only field modified (by draw print)
+                    main([11,22,33,1,2,3], {3:'0',11:'r',22:'g',33:'b'})
                     break;
                 case 'color':
-                    main([11,22,33,44,1,2,3,4])
+                    main([11,22,33,44,1,2,3,4], {3:'0',11:'r',22:'g',33:'b',44:'a'})
                     break;
                 case 'col':
                     main([11,1], {11 : 'color'})
@@ -2035,6 +2036,9 @@ function selectOption(event,id,isImport,importSelectionValue,isOnInput,from) {
                     break;
                 case 'rotate':
                     main([11,1], {11:'degrees'})
+                    break;
+                case 'reset':
+                    main([-1])
                     break;
                 default:
                     console.error(`Unhandled drawMenu selection ${option}`);

--- a/MlogDocs/ProcessorUI/script.js
+++ b/MlogDocs/ProcessorUI/script.js
@@ -378,7 +378,7 @@ function addInstruction(button, update, field1, field2, field3, field4, field5, 
             code = `<span class="editable world" contenteditable="true" order="2">${field2 || 'result'}</span>
                     <span>=</span>
                     <span>get</span>
-                    <span class="editable world" contenteditable="true" order="1" onclick="popUpMenu(event,'ulocateFindMenu')" oninput="selectOption(event,'ulocateFindMenu', null, null, 1)">${field1 || 'building'}</span>
+                    <span class="editable world" contenteditable="true" order="1" onclick="popUpMenu(event,'getBlockMenu')" oninput="selectOption(event,'getBlockMenu', null, null, 1)">${field1 || 'building'}</span>
                     <span>at</span>
                     <span class="editable world" contenteditable="true" order="3">${field3 || '0'}</span>
                     <span>,</span>

--- a/MlogDocs/ProcessorUI/script.js
+++ b/MlogDocs/ProcessorUI/script.js
@@ -2010,10 +2010,10 @@ function selectOption(event,id,isImport,importSelectionValue,isOnInput,from) {
             switch(option){
                 case 'clear':
                     // field 3 is the only field modified (by draw print)
-                    main([11,22,33,1,2,3], {3:'0',11:'r',22:'g',33:'b'})
+                    main([11,22,33,1,2,3], {11:'r',22:'g',33:'b'})
                     break;
                 case 'color':
-                    main([11,22,33,44,1,2,3,4], {3:'0',11:'r',22:'g',33:'b',44:'a'})
+                    main([11,22,33,44,1,2,3,4], {11:'r',22:'g',33:'b',44:'a'})
                     break;
                 case 'col':
                     main([11,1], {11 : 'color'})

--- a/MlogDocs/ProcessorUI/script.js
+++ b/MlogDocs/ProcessorUI/script.js
@@ -1818,6 +1818,7 @@ function selectOption(event,id,isImport,importSelectionValue,isOnInput,from) {
                     break;
                 default:
                     main([11,2], {11: '='})
+                    break;
             }
             break;
         case 'effectMenu': 
@@ -1871,6 +1872,7 @@ function selectOption(event,id,isImport,importSelectionValue,isOnInput,from) {
                     break;
                 default:
                     console.error(`Unhandled effectMenu selection ${option}`);
+                    break;
             }
             break;
         case 'fetchMenu':
@@ -1897,6 +1899,7 @@ function selectOption(event,id,isImport,importSelectionValue,isOnInput,from) {
                     break;
                 default:
                     console.error(`Unhandled fetchMenu selection ${option}`);
+                    break;
             }
             break;
         case 'controlMenu':
@@ -1914,6 +1917,7 @@ function selectOption(event,id,isImport,importSelectionValue,isOnInput,from) {
                     break;
                 default:
                     console.error(`Unhandled controlMenu selection ${option}`);
+                    break;
             }
             break;
         case 'setMarkerMenu':
@@ -1980,6 +1984,7 @@ function selectOption(event,id,isImport,importSelectionValue,isOnInput,from) {
                     break;
                 default:
                     console.error(`Unhandled setMarkerMenu selection ${option}`);
+                    break;
             }
             break;
         case 'jumpMenu':
@@ -1995,6 +2000,9 @@ function selectOption(event,id,isImport,importSelectionValue,isOnInput,from) {
                 case '>=':
                 case '===':
                     main([1,2,3,4])
+                    break;
+                default:
+                    console.error(`Unhandled jumpMenu selection ${option}`);
                     break;
             }
             break;
@@ -2054,6 +2062,7 @@ function selectOption(event,id,isImport,importSelectionValue,isOnInput,from) {
                     break;
                 default:
                     console.error(`Unhandled drawMenu selection ${option}`);
+                    break;
             }
             break;
         case 'ucontrolMenu':
@@ -2110,6 +2119,7 @@ function selectOption(event,id,isImport,importSelectionValue,isOnInput,from) {
                     break;
                 default:
                     console.error(`Unhandled ucontrolMenu selection ${option}`);
+                    break;
             }
             break;
         case 'ulocateFindMenu':
@@ -2126,6 +2136,7 @@ function selectOption(event,id,isImport,importSelectionValue,isOnInput,from) {
                     break;
                 default:
                     console.error(`Unhandled ulocateFindMenu selection ${option}`);
+                    break;
             }
             break;
         case 'setBlockMenu':
@@ -2137,6 +2148,7 @@ function selectOption(event,id,isImport,importSelectionValue,isOnInput,from) {
                     break;
                 default:
                     console.error(`Unhandled setBlockMenu selection ${option}`);
+                    break;
             }
             break;
         case 'flushMessageMenu':
@@ -2151,6 +2163,7 @@ function selectOption(event,id,isImport,importSelectionValue,isOnInput,from) {
                     break;
                 default:
                     console.error(`Unhandled flushMessageMenu selection ${option}`);
+                    break;
             }
             break;
         case 'cutsceneMenu':
@@ -2166,6 +2179,7 @@ function selectOption(event,id,isImport,importSelectionValue,isOnInput,from) {
                     break;
                 default:
                     console.error(`Unhandled cutsceneMenu selection ${option}`);
+                    break;
             }
             break;
         case 'printCharMenu':

--- a/MlogDocs/ProcessorUI/script.js
+++ b/MlogDocs/ProcessorUI/script.js
@@ -1804,6 +1804,18 @@ function selectOption(event,id,isImport,importSelectionValue,isOnInput,from) {
                 case 'unban':
                     main([11,2], {11: 'block/unit'})
                     break;
+                case 'buildSpeed':
+                case 'unitHealth':
+                case 'unitBuildSpeed':
+                case 'unitMineSpeed':
+                case 'unitCost':
+                case 'unitDamage':
+                case 'blockHealth':
+                case 'blockDamage':
+                case 'rtsMinWeight':
+                case 'rtsMinSquad':
+                    main([11,2,3], {11: 'of', 22: '='})
+                    break;
                 default:
                     main([11,2], {11: '='})
             }


### PR DESCRIPTION
- fix draw clear having wrong text and draw reset not having correct args
<img width="563" height="63" alt="image" src="https://github.com/user-attachments/assets/24b861e9-8ffa-4619-8610-48f156afd84b" />
<img width="563" height="59" alt="image" src="https://github.com/user-attachments/assets/15226179-df6c-4d37-9f79-bae347f8eb7a" />

- add and use menu for getblock (this isnt really related to select option but i got distracted)
- add team arg for certain setrule rules (this needs a better fix for correct default fields e.g. `@sharded`, without overriding existing fields)
- add default and error logging to every switch(option)